### PR TITLE
#58 Issue/58でspot_detail.phpに口コミ機能を実装

### DIFF
--- a/controller/spot_detail.php
+++ b/controller/spot_detail.php
@@ -3,16 +3,24 @@ require_once '../include/const.php';
 require_once '../include/functions.php';
 
 $user_name = '';
+//spot_id初期値0
 $spot_id = 0;
 $spots = [];
 $errors = [];
+$kuchikomi = '';
+$comments = [];
+$comment = '';
+//user_id初期値0
+$user_id = 0;
+$user_name = 'test';
+$created = '';
 
 //リクエストメソッド確認
 if (get_request_method() === 'GET'){
     $spot_id = $_GET['spot_id'];
 }
 
-//サーバー接続
+//スポット詳細取得の為のサーバー接続
 $link = get_db_connect();
 //スポット詳細情報取得
 $sql = "SELECT anime_name, spot_table.spot_id, location_table.location_id, 
@@ -36,7 +44,73 @@ if ($result = query_db($link, $sql)){
 }
 
 //サーバー切断
+//close_db_connect($link);
+
+//////////////////////////////////////以下横山
+//user_idをセッションで取得
+session_start();
+
+//ログインしていない状態
+if (isset($_SESSION['user_id']) !== TRUE) {
+
+// //ログインしている状態なら
+}else{
+    $user_id = $_SESSION['user_id'];
+    //int型に変換(不要？)
+    $user_id = intval($user_id);
+}
+
+//コメントの受取
+if (isset($_POST['comment']) === TRUE) {
+    $kuchikomi = $_POST['comment'];
+   
+    //comment_tableへの書き込みの為のサーバー接続
+    //user_id, spot_id, comment, createdを記入するsql
+    $log = date('Y-m-d H:i:s');
+    $sql = "INSERT INTO 
+                comment_table(user_id, spot_id, comment, created)
+            VALUES
+                ({$user_id}, {$spot_id}, '{$kuchikomi}', '{$log}')";
+    
+    //sql実行
+    $result = query_db($link, $sql);
+    //メモリ開放
+    //mysqli_free_result($result);
+    if ($result === FALSE) {
+        $errors[] = '口コミを追加できませんでした';
+    }
+}
+//サーバー切断
+//close_db_connect($link);
+
+//口コミ取得の為のサーバー接続
+//ユーザーネーム、コメント、日時取得
+$sql = "SELECT 
+            anime_user_table.user_name, comment, created
+        FROM 
+            comment_table
+        JOIN 
+            anime_user_table
+        ON 
+            anime_user_table.user_id = comment_table.user_id
+        WHERE 
+            comment_table.spot_id  = {$spot_id}";
+
+//sql実行
+if ($result = query_db($link, $sql)){
+    while ($row = mysqli_fetch_assoc($result)) {
+            $comments[] = $row;
+        }
+    //メモリ開放
+    mysqli_free_result($result);
+} else {
+    $errors[] = '口コミが見つかりませんでした';
+}
+
+//サーバー切断
 close_db_connect($link);
+
+
 
 $spots_json = json_encode($spots, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_UNESCAPED_UNICODE);
 $spots_json = str_replace('\n','',$spots_json); 

--- a/controller/spot_detail.php
+++ b/controller/spot_detail.php
@@ -14,6 +14,7 @@ $comment = '';
 $user_id = 0;
 $user_name = 'test';
 $created = '';
+$not_exist_comments = 1;
 
 //リクエストメソッド確認
 if (get_request_method() === 'GET'){
@@ -104,7 +105,7 @@ if ($result = query_db($link, $sql)){
     //メモリ開放
     mysqli_free_result($result);
 } else {
-    $errors[] = '口コミが見つかりませんでした';
+    $not_exist_comments;
 }
 
 //サーバー切断

--- a/include/view/spot_detail_view.php
+++ b/include/view/spot_detail_view.php
@@ -70,6 +70,7 @@
                     </form>
                 </div>
             </label>
+<?php     if($not_exist_comments === FALSE) { ?>
             <table id="comment_table">
                 <caption>口コミ一覧</caption>
                 <tr>
@@ -85,6 +86,7 @@
                 </tr>
                 <?php } ?>
             </table>
+<?php     } ?>
             <div class="return_div"><a  class="return_link" href="main.php">TOPへ戻る</a></div>
         </section>
         <script>


### PR DESCRIPTION
#58 Issue/58でspot_detail.phpに口コミ機能を実装、合わせてspot_detail_view.phpにバーダンプを記載し確認したため変更履歴あり。

「セッションの部分」「口コミがない場合の処理」部分の修正必要あり。

セッション部分はフ君が引き継ぎ。

口コミがない場合は、$commentsがnullになるが、その場合のリスト表示の仕方が分からなかった。
そのため現在、口コミがない場合は、$errors [] のなかにエラーメッセージを格納するようにしている。